### PR TITLE
Compute route based on estimated PDR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -65,18 +65,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
 dependencies = [
  "itoa",
  "memchr",
@@ -97,9 +97,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -115,7 +115,7 @@ checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 [[package]]
 name = "wg_2024"
 version = "0.1.0"
-source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#85f907eed84da8703749ff327841306d42e8af01"
+source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#07520dfe921a9050a1d69c96ae80436fe24e6155"
 dependencies = [
  "wg_internal",
 ]
@@ -123,7 +123,7 @@ dependencies = [
 [[package]]
 name = "wg_config"
 version = "0.1.0"
-source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#85f907eed84da8703749ff327841306d42e8af01"
+source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#07520dfe921a9050a1d69c96ae80436fe24e6155"
 dependencies = [
  "serde",
  "wg_network",
@@ -132,7 +132,7 @@ dependencies = [
 [[package]]
 name = "wg_controller"
 version = "0.1.0"
-source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#85f907eed84da8703749ff327841306d42e8af01"
+source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#07520dfe921a9050a1d69c96ae80436fe24e6155"
 dependencies = [
  "crossbeam-channel",
  "wg_network",
@@ -142,7 +142,7 @@ dependencies = [
 [[package]]
 name = "wg_drone"
 version = "0.1.0"
-source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#85f907eed84da8703749ff327841306d42e8af01"
+source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#07520dfe921a9050a1d69c96ae80436fe24e6155"
 dependencies = [
  "crossbeam-channel",
  "wg_controller",
@@ -153,7 +153,7 @@ dependencies = [
 [[package]]
 name = "wg_internal"
 version = "0.1.0"
-source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#85f907eed84da8703749ff327841306d42e8af01"
+source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#07520dfe921a9050a1d69c96ae80436fe24e6155"
 dependencies = [
  "wg_config",
  "wg_controller",
@@ -166,12 +166,12 @@ dependencies = [
 [[package]]
 name = "wg_network"
 version = "0.1.0"
-source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#85f907eed84da8703749ff327841306d42e8af01"
+source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#07520dfe921a9050a1d69c96ae80436fe24e6155"
 
 [[package]]
 name = "wg_packet"
 version = "0.1.0"
-source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#85f907eed84da8703749ff327841306d42e8af01"
+source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#07520dfe921a9050a1d69c96ae80436fe24e6155"
 dependencies = [
  "wg_network",
 ]
@@ -179,7 +179,7 @@ dependencies = [
 [[package]]
 name = "wg_tests"
 version = "0.1.0"
-source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#85f907eed84da8703749ff327841306d42e8af01"
+source = "git+https://github.com/WGL-2024/WGL_repo_2024.git#07520dfe921a9050a1d69c96ae80436fe24e6155"
 dependencies = [
  "crossbeam-channel",
  "wg_controller",

--- a/src/messages/commander_messages.rs
+++ b/src/messages/commander_messages.rs
@@ -28,7 +28,7 @@ pub enum SimControllerCommand {
     RegisteredServers,           // Request the list of servers to which the client is registered
     RemoveSender(NodeId),        // Remove a sender from the list of neighbors
     AddSender(NodeId, Sender<Packet>), // Add a sender to the list of neighbors
-    RequestServerType(NodeId),        // Request the type of a server
+    RequestServerType(NodeId),   // Request the type of a server
 }
 
 /**
@@ -42,10 +42,10 @@ pub enum SimControllerMessage {
     MessageReceived(NodeId, NodeId, String), // A message received by a client (server_id, node_from, message)
     TextFileResponse(u8, String),            // Response to a text file request
     MediaFileResponse(u8, Vec<u8>),          // Response to a media file request
-    FileListResponse(NodeId,Vec<u8>),        // Response  a file list request the NodeId refers to the server generating the response
-    ServerTypeResponse(NodeId, ServerType),  // Response to ServerType request from a client
+    FileListResponse(NodeId, Vec<u8>), // Response  a file list request the NodeId refers to the server generating the response
+    ServerTypeResponse(NodeId, ServerType), // Response to ServerType request from a client
     KnownServers(HashMap<NodeId, ServerType>), // Response to KnownServers request from a client
-    RegisteredServersResponse(Vec<u8>),      // Response to a list of registered servers
+    RegisteredServersResponse(Vec<u8>), // Response to a list of registered servers
 }
 
 impl DroneSend for SimControllerMessage {}

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -4,19 +4,10 @@ use serde::{Deserialize, Serialize};
 use wg_2024::network::{NodeId, SourceRoutingHeader};
 
 /// History of a drone, recording the total number of packet sent and the number of packet dropped
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct NodePacketHistory {
     pub packets_sent: u64,
     pub packets_dropped: u64,
-}
-
-impl Default for NodePacketHistory {
-    fn default() -> Self {
-        NodePacketHistory {
-            packets_sent: 0,
-            packets_dropped: 0,
-        }
-    }
 }
 
 /// A simple graph representation of the network topology

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -111,15 +111,16 @@ impl Topology {
         }
     }
 
-    /// Function that updates the history of a list of nodes, based on the drooped flag
+    /// Function that updates the history of a list of nodes, based on the drooped flag.
+    /// Should only be called for MsgFragment, since they are the only droppable packets
     ///
     /// # Args
     /// * `node_id: Vec<NodeId>` - vector of nodes to update
     /// * `dropped: bool` - if `true` then will increase the packets_dropped, else the packets_sent
-    pub fn update_node_history(&mut self, node_ids: Vec<NodeId>, dropped: bool) {
+    pub fn update_node_history(&mut self, node_ids: &Vec<NodeId>, dropped: bool) {
 
         for id in node_ids {
-            let history = self.node_histories.entry(id).or_default();
+            let history = self.node_histories.entry(*id).or_default();
             if dropped {
                 history.packets_dropped += 1;
             } else {
@@ -132,7 +133,12 @@ impl Topology {
     pub fn pdr_for_node(&mut self, node_id: NodeId) -> u64 {
 
         let history = self.node_histories.entry(node_id).or_default();
-        history.packets_dropped / history.packets_sent
+
+        if history.packets_sent > 0 {
+            history.packets_dropped / history.packets_sent
+        } else {
+            0
+        }
     }
 
     pub fn get_label(&self, node_id: NodeId) -> Option<&String> {

--- a/src/topology.rs
+++ b/src/topology.rs
@@ -7,12 +7,15 @@ use wg_2024::network::{NodeId, SourceRoutingHeader};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct NodePacketHistory {
     pub packets_sent: u64,
-    pub packets_dropped: u64
+    pub packets_dropped: u64,
 }
 
 impl Default for NodePacketHistory {
     fn default() -> Self {
-        NodePacketHistory{ packets_sent: 0, packets_dropped: 0 }
+        NodePacketHistory {
+            packets_sent: 0,
+            packets_dropped: 0,
+        }
     }
 }
 
@@ -25,7 +28,7 @@ pub struct Topology {
     node_types: HashMap<NodeId, String>,     // The types of the nodes
 
     // PDR Mapping
-    node_histories: HashMap<NodeId, NodePacketHistory>
+    node_histories: HashMap<NodeId, NodePacketHistory>,
 }
 
 impl Default for Topology {
@@ -42,7 +45,7 @@ impl Topology {
             edges: HashMap::new(),
             labels: HashMap::new(),
             node_types: HashMap::new(),
-            node_histories: HashMap::new()
+            node_histories: HashMap::new(),
         }
     }
 
@@ -60,7 +63,12 @@ impl Topology {
 
     /// Get the neighbors of a node
     pub fn neighbors(&self, node_id: NodeId) -> Vec<NodeId> {
-        self.edges.get(&node_id).unwrap_or(&HashSet::new()).iter().copied().collect()
+        self.edges
+            .get(&node_id)
+            .unwrap_or(&HashSet::new())
+            .iter()
+            .copied()
+            .collect()
     }
 
     /// Clear the topology
@@ -100,9 +108,7 @@ impl Topology {
 
     /// Function that removed the edges between two node, both from node1 to node2 and vice versa
     pub fn remove_edges(&mut self, node1: NodeId, node2: NodeId) {
-
         for (&id, neighbors) in self.edges.iter_mut() {
-
             if id == node1 {
                 neighbors.retain(|&id| id != node2);
             } else if id == node2 {
@@ -118,7 +124,6 @@ impl Topology {
     /// * `node_id: Vec<NodeId>` - vector of nodes to update
     /// * `dropped: bool` - if `true` then will increase the packets_dropped, else the packets_sent
     pub fn update_node_history(&mut self, node_ids: &Vec<NodeId>, dropped: bool) {
-
         for id in node_ids {
             let history = self.node_histories.entry(*id).or_default();
             if dropped {
@@ -131,7 +136,6 @@ impl Topology {
 
     /// Function that returns the estimated PDR, based on the history of the node
     pub fn pdr_for_node(&mut self, node_id: NodeId) -> u64 {
-
         let history = self.node_histories.entry(node_id).or_default();
 
         if history.packets_sent > 0 {


### PR DESCRIPTION
Changing the method to compute the route by taking into consideration the PDR (Packet Drop Rate) for the various nodes.

The PDR is estimated based on the number of packets sent through that node, and the amount of packets dropped by it.

NEED TO TEST AND REVIEW.